### PR TITLE
Only update apt repo list when sources changes

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -13,9 +13,10 @@ class nrsysmond::repo::debian (
   }
 
   exec {'update apt':
-    command   => 'apt-get update',
-    path      => '/usr/bin:/bin',
-    require   => Exec['load apt key'],
-    subscribe => File['/etc/apt/sources.list.d/newrelic.list'],
+    command     => 'apt-get update',
+    path        => '/usr/bin:/bin',
+    require     => Exec['load apt key'],
+    refreshonly => true,
+    subscribe   => File['/etc/apt/sources.list.d/newrelic.list'],
   }
 }


### PR DESCRIPTION
Currently Exec[update apt] is "subscribes" to the newrelic apt source file.
However, without the refreshonly parameter set, the Exec will run every time
Puppet is run.
