### PR TITLE
rake, spec and CentOS 7 fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem 'puppet'
 gem 'puppetlabs_spec_helper'
+gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.6.2'
+gem "puppet-lint", '~> 1.0.0'
+gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+gem "puppet-syntax"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,38 @@
+GIT
+  remote: https://github.com/rodjek/rspec-puppet.git
+  revision: 8459e14807977244c00bdbcf190062c529b63474
+  specs:
+    rspec-puppet (2.0.0)
+      rspec (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     diff-lcs (1.1.3)
-    facter (1.6.17)
-    hiera (1.0.0)
+    facter (2.4.0)
+      CFPropertyList (~> 2.2.6)
+    hiera (1.3.4)
+      json_pure
+    json_pure (1.8.2)
     metaclass (0.0.1)
     mocha (0.13.1)
       metaclass (~> 0.0.1)
-    puppet (3.0.2)
-      facter (~> 1.6.11)
-      hiera (~> 1.0.0)
+    puppet (3.6.2)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+      rgen (~> 0.6.5)
+    puppet-lint (1.0.1)
+    puppet-syntax (1.4.1)
+      rake
     puppetlabs_spec_helper (0.4.0)
       mocha (>= 0.10.5)
       rake
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.3)
+    rgen (0.6.6)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -24,12 +41,13 @@ GEM
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.1)
-    rspec-puppet (0.1.5)
-      rspec
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  puppet
+  puppet (~> 3.6.2)
+  puppet-lint (~> 1.0.0)
+  puppet-syntax
   puppetlabs_spec_helper
+  rspec-puppet!

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,24 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
+
+PuppetLint.configuration.send("disable_80chars")
+# autoloader layout breaks if the git repo/clone name != module name
+PuppetLint.configuration.send("disable_autoloader_layout")
+PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = true
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,12 @@ PuppetLint.configuration.send("disable_autoloader_layout")
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 
+# Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
+# http://puppet-lint.com/checks/class_parameter_defaults/
+PuppetLint.configuration.send('disable_class_parameter_defaults')
+# http://puppet-lint.com/checks/class_inherits_from_params_class/
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
 exclude_paths = [
   "pkg/**/*",
   "vendor/**/*",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,3 +1,12 @@
+# = Class: nrsysmond::config
+#
+# This class configures nrsysmond. This is an internal class that
+# should only be called from nrsysmond.
+#
+# == Actions
+#
+#   - Write out /etc/newrelic/nrsysmond.cfg from template
+#
 class nrsysmond::config(
   $license_key,
   $nrloglevel     = $nrsysmond::params::loglevel,
@@ -14,15 +23,15 @@ class nrsysmond::config(
   validate_re($license_key, '[0-9a-fA-F]{40}', 'License key is not a 40 character hexadecimal string')
 
   if (!member(['error', 'warning', 'info',
-               'verbose', 'debug', 'verbosedebug'], $nrloglevel)) {
+                'verbose', 'debug', 'verbosedebug'], $nrloglevel)) {
     fail("Log level of ${nrloglevel} was invalid.")
   }
 
   file { '/etc/newrelic/nrsysmond.cfg':
-    owner    => root,
-    group    => root,
-    mode     => 644,
-    content  => template('nrsysmond/nrsysmond.cfg.erb'),
-    notify   => Service["newrelic-sysmond"],
+    owner   => root,
+    group   => root,
+    mode    => '0644',
+    content => template('nrsysmond/nrsysmond.cfg.erb'),
+    notify  => Service['newrelic-sysmond'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,12 +130,14 @@ class nrsysmond (
     }
   }
 
+  $osfam_req = $::osfamily ? {
+    'RedHat' => Class['nrsysmond::repo::redhat'],
+    'Debian' => Class['nrsysmond::repo::debian'],
+  }
+
   package { 'newrelic-sysmond':
     ensure  => $version,
-    require => $::osfamily ? {
-      'RedHat' => Class['nrsysmond::repo::redhat'],
-      'Debian' => Class['nrsysmond::repo::debian'],
-    }
+    require => $osfam_req,
   }
 
   class {'nrsysmond::config':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,7 +124,7 @@ class nrsysmond (
       # https://support.newrelic.com/requests/130089
       # workaround for RPM that's broken on Cent7+ (or any other distro
       # that uses shadow-utils >= 4.1.5 )
-      if ( $::operatingsystemmajrelease == '7' or $::operatingsystemmajrelease == 7 ) {
+      if ( $::selinux == true or $::selinux == 'true' ) {
         group {'newrelic':
           ensure     => 'present',
           forcelocal => true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,7 @@
+# = Class: nrsysmond::params
+#
+# Provides default parameter values for nrsysmond
+#
 class nrsysmond::params {
   case $::osfamily {
     'RedHat': {
@@ -9,6 +13,9 @@ class nrsysmond::params {
     }
     'Debian': {
       $apt_repo = 'http://apt.newrelic.com/debian/'
+    }
+    default: {
+      fail("ERROR: nrsysmond is not supported on osfamily ${::osfamily}")
     }
   }
   $version  = 'latest'

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,8 +1,12 @@
+# = Class: nrsysmond::repo::debian
+#
+# Installs NewRelic apt repo via a file resource and execs to add the apt key and apt-get update
+#
 class nrsysmond::repo::debian (
   $apt_repo = $::nrsysmond::params::apt_repo
 ) inherits nrsysmond::params {
   file { '/etc/apt/sources.list.d/newrelic.list':
-    ensure => present,
+    ensure  => present,
     content => "deb ${apt_repo} newrelic non-free",
   }
 

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -1,3 +1,7 @@
+# = Class: nrsysmond::repo::redhat
+#
+# Installs NewRelic Yum repository via an exec of /bin/rpm
+#
 class nrsysmond::repo::redhat (
   $rpm_repo_location = $::nrsysmond::params::rpm_repo_location,
 ) inherits nrsysmond::params {

--- a/spec/classes/nrsysmond_spec.rb
+++ b/spec/classes/nrsysmond_spec.rb
@@ -5,7 +5,7 @@ describe 'nrsysmond' do
 
   context 'Invalid license key' do
     let(:params) { {:license_key => 'foobar' }}
-
+    let(:facts) { {:osfamily => 'RedHat' }}
       it {
         expect {
           should include_class('nrsysmond::params')
@@ -23,7 +23,7 @@ describe 'nrsysmond' do
       it { should contain_class('nrsysmond::config').with(
         'license_key' => 'asdfdsa51c05cbdcc1dc3e78fa981c2f4790e6902fd1c4f',
         'nrlogfile'   => '/var/log/newrelic/nrsysmond.log',
-        'nrloglevel'  => 'info'
+        'nrloglevel'  => 'error'
       )}
 
       it { should contain_service 'newrelic-sysmond' }

--- a/spec/classes/nrsysmond_spec.rb
+++ b/spec/classes/nrsysmond_spec.rb
@@ -32,21 +32,8 @@ describe 'nrsysmond' do
     end
   end
 
-  context "on Non-RedHat" do
-    let(:facts) {{:osfamily => 'Debian'}}
-    describe 'should not manage user' do
-      it { should compile.with_all_deps }
-      it { should_not contain_group('newrelic') }
-      it { should_not contain_user('newrelic') }
-      it { should contain_package('newrelic-sysmond').with(
-                    :require => 'Class[Nrsysmond::Repo::Debian]',
-      )}
-    end
-  end
-
-
-  context "on RedHat < 7" do
-    let(:facts) {{:osfamily => 'RedHat', :operatingsystemmajrelease => 6}}
+  context "without SELinux" do
+    let(:facts) {{:osfamily => 'RedHat', :selinux => 'false'}}
     describe 'should not manage user' do
       it { should compile.with_all_deps }
       it { should_not contain_group('newrelic') }
@@ -57,8 +44,8 @@ describe 'nrsysmond' do
     end
   end
 
-  context "on RedHat >= 7" do
-    let(:facts) {{:osfamily => 'RedHat', :operatingsystemmajrelease => 7}}
+  context "with SELinux" do
+    let(:facts) {{:osfamily => 'RedHat', :selinux => 'true'}}
     describe 'should manage user' do
       it { should compile.with_all_deps }
       it { should contain_group('newrelic').with(


### PR DESCRIPTION
(1) Fix a number of Rake and spec issues so the tests actually __work__.

(2) Per https://support.newrelic.com/requests/130089, have Puppet manage the group and user on RedHat 7. This is because of a broken useradd command in the RPM that fails on distros using shadow-utils >= 4.1.5. I strongly disagree with fixing a broken RPM in a Puppet module, but this is what Support told me to do.

On a side note:
(1) This module is way out of date in terms of Puppet module standards. It uses a number of deprecated patterns and the spec tests are woefully incomplete. When Puppet4 comes out (which is going to be soon), this module will no longer be functional.
(2) There are a number of places for improvement, such as the exec used to install the Yum repository, when there's a native type for this.