### PR TITLE
Adding ability to specify the hostname to register with

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@
 #
 class nrsysmond::config(
   $license_key,
+  $hostname       = undef,
   $nrloglevel     = $nrsysmond::params::loglevel,
   $nrlogfile      = $nrsysmond::params::logfile,
   $proxy          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,18 @@
 #   40-character alphanumeric string provided by New Relic. This is required in
 #   order for the server monitor to start.
 #
+# [*hostname*]
+#   Sets the hostname of the server as it appears in New Relic. If not
+#   specified, the OS-level hostname will be used.
+#   Caution: The New Relic user interface uses the hostname to link monitored
+#   applications to the server they are running on. Using the hostname
+#   configuration setting in the nrsysmond.cfg file may cause a different name
+#   to be reported for the server than what is reported by any monitored
+#   applications. This difference may cause the linkage between the application
+#   and the server in the New Relic user interface to break.
+#   See https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name#configuration-file
+#   **Default**: undef
+#
 # [*nrloglevel*]
 #   Level of detail you want in the log file (as defined by the logfile
 #   setting below. Valid values are (in increasing levels of verbosity):
@@ -113,6 +125,7 @@
 #
 class nrsysmond (
   $license_key,
+  $hostname       = undef,
   $nrloglevel     = $::nrsysmond::params::loglevel,
   $nrlogfile      = $::nrsysmond::params::logfile,
   $proxy          = undef,
@@ -149,6 +162,7 @@ class nrsysmond (
 
   class {'nrsysmond::config':
     license_key    => $license_key,
+    hostname       => $hostname,
     nrloglevel     => $nrloglevel,
     nrlogfile      => $nrlogfile,
     proxy          => $proxy,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'nrsysmond::config' do
+  context 'with valid osfamily' do
+    let(:facts) { {:osfamily => 'RedHat', :hardwaremodel => 'x86_64'} }
+
+    context 'and no hostname does not include hostname in cfg' do
+      let(:params) {
+        {
+          :license_key  => '0123456789ABCDEFabcdef2345678901234567Zz',
+        }
+      }
+
+      it {
+        should contain_file('/etc/newrelic/nrsysmond.cfg') \
+          .without_content(/hostname=/)
+      }
+    end
+
+    context 'and hostname includes hostname in cfg' do
+      let(:params) {
+        {
+          :license_key  => '0123456789ABCDEFabcdef2345678901234567Zz',
+          :hostname     => 'foo.newrelic.com',
+        }
+      }
+
+      it {
+        should contain_file('/etc/newrelic/nrsysmond.cfg') \
+          .with_content(/^hostname=foo.newrelic.com$/)
+      }
+    end
+
+  end
+
+end

--- a/spec/classes/nrsysmond_spec.rb
+++ b/spec/classes/nrsysmond_spec.rb
@@ -7,7 +7,7 @@ describe 'nrsysmond' do
     let(:facts) { {:osfamily => 'RedHat' }}
       it {
         expect {
-          should include_class('nrsysmond::params')
+          should contain_class('nrsysmond::params')
         }.to raise_error(Puppet::Error, /40 character alphanumeric/)
       }
   end
@@ -33,7 +33,7 @@ describe 'nrsysmond' do
   ['RedHat', 'Debian'].each do |platform|
     context "#{platform} osfamily" do
       let(:facts) { {:osfamily => platform} }
-      it { should include_class('nrsysmond::params')}
+      it { should contain_class('nrsysmond::params')}
 
       it { should contain_package 'newrelic-sysmond'}
 
@@ -50,7 +50,7 @@ describe 'nrsysmond' do
   context 'Non-Ubuntu and non-RedHat osfamily' do
     it do
       expect {
-        should include_class('nrsysmond::params')
+        should contain_class('nrsysmond::params')
       }.to raise_error(Puppet::Error, /not supported/)
     end
   end

--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -15,6 +15,23 @@
 #
 license_key=<%= @license_key %>
 
+<% if @hostname %>
+#
+# Option : hostname
+# Value  : Sets the hostname of the server as it appears in New Relic. If not
+#          specified, the OS-level hostname will be used.
+#          Caution: The New Relic user interface uses the hostname to link monitored
+#          applications to the server they are running on. Using the hostname
+#          configuration setting in the nrsysmond.cfg file may cause a different name
+#          to be reported for the server than what is reported by any monitored
+#          applications. This difference may cause the linkage between the application
+#          and the server in the New Relic user interface to break.
+#          See https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name#configuration-file
+# Default: none
+#
+hostname=<%= @hostname %>
+
+<% end -%>
 #
 # Option : loglevel
 # Value  : Level of detail you want in the log file (as defined by the logfile


### PR DESCRIPTION
Adding support for the hostname parameter (https://docs.newrelic.com/docs/servers/new-relic-servers-linux/maintenance/changing-linux-server-name#configuration-file) to allow users to specify a custom hostname.

Also, fixed deprecation warning from puppet-rspec to use contain_class instead of include_class.