### PR TITLE
Use HTTPS everywhere for New Relic endpoints

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,13 +6,13 @@ class nrsysmond::params {
   case $::osfamily {
     'RedHat': {
       if $::hardwaremodel == 'x86_64' {
-        $rpm_repo_location = 'http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm'
+        $rpm_repo_location = 'https://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm'
       } else {
-        $rpm_repo_location = 'http://yum.newrelic.com/pub/newrelic/el5/i386/newrelic-repo-5-3.noarch.rpm'
+        $rpm_repo_location = 'https://yum.newrelic.com/pub/newrelic/el5/i386/newrelic-repo-5-3.noarch.rpm'
       }
     }
     'Debian': {
-      $apt_repo = 'http://apt.newrelic.com/debian/'
+      $apt_repo = 'https://apt.newrelic.com/debian/'
     }
     default: {
       fail("ERROR: nrsysmond is not supported on osfamily ${::osfamily}")

--- a/spec/classes/repo/redhat_spec.rb
+++ b/spec/classes/repo/redhat_spec.rb
@@ -3,6 +3,6 @@ require 'spec_helper'
 describe 'nrsysmond::repo::redhat' do
   context "x86_64 hardwaremodel" do
     let(:facts) { {:osfamily => 'RedHat', :hardwaremodel => 'x86_64'} }
-    it { should contain_exec('install repo').with_command('/bin/rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm')}
+    it { should contain_exec('install repo').with_command('/bin/rpm -Uvh https://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm')}
   end
 end


### PR DESCRIPTION
New Relic support HTTPS on these endpoints so let's use it!

#14 takes care of the fetching the GPG key over HTTPS.