### PR TITLE
Sort labels hash to create consistency.

### DIFF
--- a/templates/nrsysmond.cfg.erb
+++ b/templates/nrsysmond.cfg.erb
@@ -147,7 +147,7 @@ timeout=<%= @timeout %>
 # Default: none
 
 <% if @labels %>
-labels="<% @labels.each do |key, value| -%><%= key %>:<%= value %>;<% end %>"
+labels="<% @labels.sort.each do |key_value| -%><%= key_value[0] %>:<%= key_value[1] %>;<% end %>"
 <% else %>
 #labels=
 <% end %>


### PR DESCRIPTION
Since Hash's in Ruby are not stored in an ordered fashion, the configuration template resource get recreated every few puppet runs. This also restarts the newrelic agent on the server.

To solve this I sorted the hash so that the template result is consistent between runs.